### PR TITLE
Make the LoggingModule.Log method public

### DIFF
--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -27,6 +27,7 @@ namespace Test
             log.Critical("This is a Critical message.");
             log.Emergency("This is an Emergency message.");
             log.Info("Let's test logging an exception.");
+            log.Log(Severity.Info, "Just another way to create logs");
 
             int numerator = 15;
             int denominator = 0;


### PR DESCRIPTION
The base method of all log methods (warn, error, info, ...) is now public
to make it callable from outside. The severity can then be passed via
parameter. This allows makes it possible to dynamically log different log
levels without having to use a switch statement.